### PR TITLE
Linux, etc support

### DIFF
--- a/WinMain.h
+++ b/WinMain.h
@@ -45,6 +45,8 @@ protected:
 	void dropEvent(QDropEvent* event) Q_DECL_OVERRIDE;
 
 private:
+	/** Open a file-chooser to locate config folder manually. */
+	QString locateConfigFolder();
 	void addNewData(QAbstractItemModel* model, const QModelIndex& parent, int position, const QFileInfo& target);
 
 	Ui::WinMain *ui;


### PR DESCRIPTION
Check for the config folder in the default flatpak location on linux. Could later add some other locations it might reasonably be.

On whatever platform, if the directory isn't automatically found, now shows a file-chooser to manually locate it.

Tested on Debian Buster